### PR TITLE
Add some UDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axolotls
 
-Axolotls implements [Arrow Memory Layout](https://arrow.apache.org/docs/format/Columnar.html#physical-memory-layout) on top of PyTorch, with lightweight DataFrame-flavored API.
+Axolotls implements [Arrow Memory Layout](https://arrow.apache.org/docs/format/Columnar.html#physical-memory-layout) on top of PyTorch, with lightweight DataFrame-flavored API. Such structures are often useful to perform pre-processing after data is in Tensor format.
 
 ## Installation
 

--- a/axolotls/dtypes.py
+++ b/axolotls/dtypes.py
@@ -1,4 +1,4 @@
-# Based on https://github.com/pytorch/torcharrow/blob/ba822da72825150e971c3ee7b6dcb81668eb79f2/torcharrow/dtypes.py
+# Forked from https://github.com/pytorch/torcharrow/blob/ba822da72825150e971c3ee7b6dcb81668eb79f2/torcharrow/dtypes.py
 # Changes may apply
 
 # Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -587,5 +587,9 @@ def _dtype_from_pytorch_dtype(dtype: torch.dtype, nullable: bool = False) -> DTy
         return Int32(nullable=nullable)
     if dtype == torch.int64:
         return Int64(nullable=nullable)
+    if dtype == torch.float32:
+        return Float32(nullable=nullable)
+    if dtype == torch.float64:
+        return Float32(nullable=nullable)
 
     raise ValueError(f"Unsupported PyTorch dtype: {dtype}")

--- a/axolotls/functional/velox.py
+++ b/axolotls/functional/velox.py
@@ -1,0 +1,18 @@
+from typing import Callable
+from ..column_base import ColumnBase
+from ..list_column import ListColumn
+
+# TODO: lambda capture is not supported yet
+def transform_(col: ListColumn, func: Callable[[ColumnBase], None]):
+    func(col.values)
+    return col
+
+# TODO: lambda capture is not supported yet
+def transform(col: ListColumn, func: Callable[[ColumnBase], ColumnBase]):
+    values = func(col.values)
+
+    return ListColumn(
+        values=values,
+        offsets=col.offsets,
+        presence=col.presence,
+    )

--- a/axolotls/list_column.py
+++ b/axolotls/list_column.py
@@ -12,6 +12,8 @@ class ListColumn(ColumnBase):
     ) -> None:
         super().__init__(dtype=dt.List(values.dtype, nullable=presence is not None))
 
+        if not isinstance(values, ColumnBase):
+            raise ValueError("ListColumn expects values to be ColumnBase")
         if offsets.dim() != 1:
             raise ValueError("ListColumn expects 1D offsets Tensor")
 

--- a/axolotls/numeric_column.py
+++ b/axolotls/numeric_column.py
@@ -24,6 +24,31 @@ class NumericColumn(ColumnBase):
         else:
             raise ValueError(f"Unsupported key for __getitem__: f{key}")
 
+    def fill_null(self, val):
+        if self.presence is None:
+            # TODO: should we return a copy here?
+            return self
+
+        values = self.values.clone()
+        values[~self.presence] = val
+        return NumericColumn(values=values)
+
+    def fill_null_(self, val):
+        if self.presence is None:
+            return self
+        
+        self.values[~self.presence] = val
+        self._presence = None
+        self._dtype = self._dtype.with_null(nullable=False)
+
+        return self
+
+    # Common PyTorch ops
+    def logit(self, eps=None):
+        return NumericColumn(
+            values=self.values.logit(eps),
+            presence=self.presence,
+        )
 
     @property
     def values(self) -> torch.Tensor:


### PR DESCRIPTION
* fill_null
* initial lambda support: functional.velox.transform
* logit

```python
>>> import torch
>>> import axolotls as ax
>>> col = ax.ListColumn(values=ax.NumericColumn(torch.rand(10)), offsets=torch.tensor([0, 3, 4, 9, 10]))
>>> col
0  [0.1509007215499878, 0.6603289246559143, 0.15724843740463257]
1  [0.7157279849052429]
2  [0.3467774987220764, 0.7036508321762085, 0.7037603259086609, 0.9888301491737366, 0.2074815034866333]
3  [0.6024075746536255]
dtype: List(float32), length: 4

>>> from axolotls.functional import velox as VF
>>> VF.transform(col, lambda col: col.logit())
0  [-1.7275539636611938, 0.6647603511810303, -1.6788452863693237]
1  [0.9233685731887817]
2  [-0.6332345008850098, 0.8647438287734985, 0.8652690649032593, 4.483304500579834, -1.3401737213134766]
3  [0.41550686955451965]
dtype: List(float32), length: 4
```

`fill_null`: 
```python
>>> import axolotls as ax
>>> import torch
>>> col = ax.NumericColumn(torch.tensor([1, 0, 3, 4, 5, 6, 7, 8]), presence=torch.tensor([True, False, True, True, False, True, True, True]))
>>> list_col = ax.ListColumn(col, offsets=torch.tensor([0, 1, 3, 6, 8]))
>>> list_col
0  [1]
1  [None, 3]
2  [4, None, 6]
3  [7, 8]
dtype: List(Int64(nullable=True)), length: 4
>>> col
0  1
1  None
2  3
3  4
4  None
5  6
6  7
7  8
dtype: Int64(nullable=True), length: 8
>>> col.fill_null(-1)
0   1
1  -1
2   3
3   4
4  -1
5   6
6   7
7   8
dtype: int64, length: 8

>>> from axolotls.functional import velox as VF
>>> VF.transform(list_col, lambda col: col.fill_null(-2))
0  [1]
1  [-2, 3]
2  [4, -2, 6]
3  [7, 8]
dtype: List(int64), length: 4
```