### PR TITLE
Experimental feature: zero-copy to_arrow()

### DIFF
--- a/axolotls/column_base.py
+++ b/axolotls/column_base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from . import dtypes as dt
-from tabulate import tabulate
 
 class ColumnBase(ABC):
     @abstractmethod
@@ -34,6 +33,12 @@ class ColumnBase(ABC):
     def __str__(self) -> str:
         return self.__repr__()
 
- 
+
+    @abstractmethod
+    def to_arrow(self):
+        """
+        Experimental interop API with soft dependency on PyArrow
+        """
+        raise NotImplementedError
 
     

--- a/axolotls/numeric_column.py
+++ b/axolotls/numeric_column.py
@@ -60,3 +60,12 @@ class NumericColumn(ColumnBase):
 
     def __len__(self) -> int:
         return len(self._values)
+
+    def to_arrow(self):
+        # TODO: Check whether PyArrow is available 
+        import pyarrow as pa
+
+        values = self.values.numpy()
+        mask = ~self.presence.numpy() if self.presence is not None else None
+
+        return pa.array(values, mask=mask)

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,10 @@ setup(
     # Metadata
     name='axolotls',
     version=VERSION,
-    description='Composable data loading modules for PyTorch',
-    url='https://github.com/pytorch/data',
-    author='PyTorch Team',
-    author_email='packages@pytorch.org',
+    description='Lightweight DataFrame library on PyTorch',
+    url='https://github.com/wenleix/axolotls',
+    author='Wenlei Xie',
+    author_email='wenlei.oss.pure@gmail.com',
     license='BSD',
     install_requires=[
         'requests',


### PR DESCRIPTION
Make pyarrow as soft-dep.

```python
>>> import axolotls as ax
>>> import torch

>>> col = ax.NumericColumn(torch.tensor([1, 0, 3, 4, 0, 6, 7, 8]), presence=torch.tensor([True, False, True, True, False, True, True, True]))
>>> col.to_arrow()
<pyarrow.lib.Int64Array object at 0x7fbab0a63130>
[
  1,
  null,
  3,
  4,
  null,
  6,
  7,
  8
]
>>> list_col = ax.ListColumn(col, offsets=torch.tensor([0, 1, 3, 6, 8]))
>>> list_col.to_arrow()
<pyarrow.lib.ListArray object at 0x7fbab0a632f0>
[
  [
    1
  ],
  [
    null,
    3
  ],
  [
    4,
    null,
    6
  ],
  [
    7,
    8
  ]
]
```