### PR TITLE
Further tweak on __str__

### DIFF
--- a/axolotls/demo/criteo.py
+++ b/axolotls/demo/criteo.py
@@ -40,10 +40,10 @@ df["dense_grp"] = (df["dense_grp"] + 3).log()
 
 print(f"df\n{df.__repr__()}\n")
 
-print(str(df["dense1"]))
-print(str(df["dense3"]))
+print(str(df["dense1"]) + "\n")
+print(str(df["dense3"]) + "\n")
 
 col = ax.NumericColumn(torch.tensor([1, -100, 3, 4, -100, 6, 7, 8]), presence=torch.tensor([True, False, True, True, False, True, True, True]))
 list_col = ax.ListColumn(col, offsets=torch.tensor([0, 1, 3, 6, 8]))
 
-print(str(list_col))
+print(str(list_col) + "\n")

--- a/axolotls/list_column.py
+++ b/axolotls/list_column.py
@@ -50,13 +50,13 @@ class ListColumn(ColumnBase):
     def __str__(self) -> str:
         values_str = str(self.values)
         values_lines = values_str.splitlines(True)
-        values_str = values_lines[0] + '\t' + '\t'.join(values_lines[1:])
+        values_str = values_lines[0] + '    ' + '    '.join(values_lines[1:])
 
         return f"""ListColumn(
-\tvalues={values_str},
-\toffsets={self.offsets},
-\tpresence={self.presence},
-\tdtype={self.dtype}
+    values={values_str},
+    offsets={self.offsets},
+    presence={self.presence},
+    dtype={self.dtype},
 )
 """
 

--- a/axolotls/numeric_column.py
+++ b/axolotls/numeric_column.py
@@ -35,12 +35,11 @@ class NumericColumn(ColumnBase):
         raise ValueError(f"Unsupported key for __getitem__: f{key}")
 
     def __str__(self) -> str:
-        return f"""NumericaColumn(
+        return f"""NumericColumn(
     values={self.values},
     presence={self.presence},
     dtype={self.dtype},
-)
-"""
+)"""
 
     @property
     def values(self) -> torch.Tensor:


### PR DESCRIPTION
Output from `python axolotls/demo/criteo.py`:

(Note, dtype is printed out for developer to look at, dtype in theory doesn't need to be part of Column and can be computed online)

```python
NumericColumn(
    values=tensor([7.2335, 1.6094, 1.6094, 1.0986, 1.7918]),
    presence=None,
    dtype=float32,
)

NumericColumn(
    values=tensor([   2,   44,    1, -100, -100]),
    presence=tensor([ True,  True,  True, False, False]),
    dtype=Int64(nullable=True),
)

ListColumn(
    values=NumericColumn(
        values=tensor([   1, -100,    3,    4, -100,    6,    7,    8]),
        presence=tensor([ True, False,  True,  True, False,  True,  True,  True]),
        dtype=Int64(nullable=True),
    ),
    offsets=tensor([0, 1, 3, 6, 8]),
    presence=None,
    dtype=List(Int64(nullable=True)),
)
```