### PR TITLE
Initial StringColumn support

### DIFF
--- a/axolotls/__init__.py
+++ b/axolotls/__init__.py
@@ -1,3 +1,4 @@
 from .numeric_column import NumericColumn
+from .string_column import StringColumn
 from .list_column import ListColumn
 from .struct_column import StructColumn

--- a/axolotls/demo/string_col.py
+++ b/axolotls/demo/string_col.py
@@ -35,3 +35,10 @@ print(col2.__repr__() + '\n')
 print(str(col2))
 
 print(col2.to_arrow().__repr__())
+print("\n------------------------------------\n")
+
+# Create StringColumn directly from values and offsets Tensor
+strs = "abcde你好"
+values = torch.frombuffer(strs.encode('utf-8'), dtype=torch.uint8)
+col3 = ax.StringColumn(values, offsets=torch.IntTensor([0, 5, 11]))
+print(col3.__repr__() + '\n')

--- a/axolotls/demo/string_col.py
+++ b/axolotls/demo/string_col.py
@@ -1,0 +1,37 @@
+import pyarrow as pa
+import axolotls as ax
+import torch
+
+arr1 = pa.array(["abc", "de", "XYZ", "abcXYZ", "123"])
+col1 = ax.StringColumn.from_arrow(arr1)
+
+print(col1.__repr__() + '\n')
+print(col1[2:].__repr__() + '\n')
+
+print(str(col1) + "\n")
+
+print(col1.to_arrow().__repr__())
+print(str(col1[2:]) + "\n")
+print(col1[2:].to_arrow().__repr__())
+
+
+print("\n------------------------------------\n")
+
+# List[String]
+list_col = ax.ListColumn(
+    values=col1,
+    offsets=torch.tensor([0, 2, 3, 5])
+)
+
+print(list_col.__repr__() + '\n')
+print(str(list_col))
+
+print("\n------------------------------------\n")
+
+arr2 = pa.array(["abc", "de", "XYZ", "不只是ascii"])
+col2 = ax.StringColumn.from_arrow(arr2)
+
+print(col2.__repr__() + '\n')
+print(str(col2))
+
+print(col2.to_arrow().__repr__())

--- a/axolotls/string_column.py
+++ b/axolotls/string_column.py
@@ -1,0 +1,102 @@
+import string
+from .column_base import ColumnBase
+from . import dtypes as dt
+from typing import Optional
+import torch
+
+class StringColumn(ColumnBase):
+    def __init__(
+        self, 
+        values: torch.ByteTensor, 
+        offsets: torch.Tensor,
+    ) -> None:
+        # String Column doesn't support null value for now
+        # It is straightforward to support it (with extra optional), but hold on for simplicity, 
+        #   and only add it once there is clear use cases.
+        super().__init__(dtype=dt.string)
+
+        if not isinstance(values, torch.ByteTensor) or values.dim() != 1:
+            raise ValueError("StringColumn expects values to be 1D ByteTensor")
+        if not isinstance(offsets, torch.Tensor) or offsets.dim() != 1 or offsets.dtype != torch.int32:
+            raise ValueError("StringColumn expects 1D offsets int32 Tensor")
+
+        self._values = values
+        self._offsets = offsets
+
+    def clone(self) -> "StringColumn":
+        return StringColumn(
+            values=self.values.detach().clone(),
+            offsets=self.offsets.detach().clone(),
+        )
+
+    def __getitem__(self, key) -> str:
+        if isinstance(key, int):
+            bytes: torch.ByteTensor = self.values[self.offsets[key] : self.offsets[key + 1]]
+            return bytearray(bytes).decode('utf-8')
+
+        if isinstance(key, slice):
+            # non-continugous slice is not supported yet
+            assert key.step is None
+            start = key.start or 0
+            stop = key.stop or len(self)
+
+            values = self.values[self.offsets[start] : self.offsets[stop]]
+
+            # convert offsets to length for selection
+            lengths: torch.Tensor = self.offsets[1:] - self.offsets[:-1]
+            lengths = lengths[key]
+            # convert selected lengths back to offsets
+            offsets = torch.cat((
+                torch.tensor([0], dtype=torch.int32),
+                torch.cumsum(lengths, dtype=torch.int32, dim=0)
+            ))
+
+            return StringColumn(values=values, offsets=offsets)
+
+        raise ValueError(f"Unsupported key for __getitem__: f{key}")
+
+    def __str__(self) -> str:
+        return f"""StringColumn(
+    values={self.values},
+    offsets={self.offsets},
+    dtype={self.dtype},
+)"""
+
+    @property
+    def values(self) -> torch.ByteTensor:
+        return self._values
+
+    @property
+    def offsets(self) -> torch.Tensor:
+        return self._offsets
+
+    def __len__(self) -> int:
+        return len(self._offsets) - 1
+
+    def to_arrow(self):
+        import pyarrow as pa
+        from .utils import _get_arrow_buffer_from_tensor
+
+        values_buffer = _get_arrow_buffer_from_tensor(self.values)
+        offsets_buffer = _get_arrow_buffer_from_tensor(self.offsets)
+
+        return pa.Array.from_buffers(
+            type=pa.string(),
+            length=len(self),
+            buffers=[None, offsets_buffer, values_buffer],  # validity buffer is None
+        )
+
+    @staticmethod
+    def from_arrow(array):
+        import pyarrow as pa
+        
+        if not isinstance(array, pa.Array) or array.type != pa.string():
+            raise ValueError(f"Expect array to be a StringArray")
+        if array.null_count != 0:
+            raise ValueError(f"Expect array contains no NULL")
+
+        buffers = array.buffers()
+        return StringColumn(
+            values=torch.frombuffer(buffers[2], dtype=torch.uint8),
+            offsets=torch.frombuffer(buffers[1], dtype=torch.int32),
+        )

--- a/axolotls/utils.py
+++ b/axolotls/utils.py
@@ -1,0 +1,10 @@
+import torch
+
+def _get_arrow_buffer_from_tensor(tensor: torch.Tensor):
+    import pyarrow as pa
+
+    return pa.foreign_buffer(
+        address=tensor.data_ptr(),
+        size=tensor.element_size() * tensor.numel(),
+        base=tensor
+    )


### PR DESCRIPTION
Following Arrow Memory Layout, A list of (UTF-8 encoded) strings is
stored in the following way:
* The `values` 1D ByteTensor, which store the bytes after concatenating
  all the strings.
* The `offsets` Tensor denote how to "cut" each individual string from
  the concatenated 1D ByteTensor. Especially, the ith string is stored
  in `values[offsets[i] : offsets[i+1]]`

For example, the following string list:
```
0  abc
1  de
2  XYZ
3  abcXYZ
4  123
dtype: string, length: 5
```

is stored as
```python
StringColumn(
    values=tensor([ 97,  98,  99, 100, 101,  88,  89,  90,  97,  98,  99,  88,  89,  90,
         49,  50,  51], dtype=torch.uint8),
    offsets=tensor([ 0,  3,  5,  8, 14, 17], dtype=torch.int32),
    dtype=string,
)
```

An interesting question is how to author string kernels. I can see
three sources:
* (Re-implementation) Implemented (or fork the code from Arrow/Velox
  kernels) as native PyTorch ops (over values+offsets Tensor). Such as
  most common perf-critical kernels, or some kernels already has deps
  on PyTorch (e.g. tokenization and vocab_lookup kernels from TorchText)
* (Re-dispatch in C++) Implemented as PyTorch wrapper op that
  redispatches to Velox/Arrow/cuDF kernels. The published `_axolotls.so`
  will be statically link to these kernels (which can be a submodule or
  forked) and need to contain the kernel eval part of Velox/Arrow/cuDF.
  So might be difficult for devinfra.
* (Wrap in Python) Convert to pandas/pyarrow/cudf for rich analytics
  (which not only supports rich string functions, but also complicated
  aggr/join/window functions, etc). This is similar to the relationship
  between PyTorch and NumPy/SciPy (i.e. PyTorch has zero-copy
  conversion to NumPy arrays, thus can convert to NumPy array if rich
  scientific computing is required).